### PR TITLE
Accept Lists of END tag type

### DIFF
--- a/src/read.cpp
+++ b/src/read.cpp
@@ -122,7 +122,7 @@ namespace
 
     std::unique_ptr<tag_list> read_list(std::istream& is)
     {
-        tag::tag_type tt = read_type(is);
+        tag::tag_type tt = read_type(is, true);
 
         auto tp = make_uq<tag_list>(tt);
 


### PR DESCRIPTION
Courtesy of the latest minecraft versions, sometimes a List will be made of END types. This patch enables the parsing of those lists.
