### PR TITLE
Fix Compilation Issue (C++14) & GCC Warning

### DIFF
--- a/include/tag_list.h
+++ b/include/tag_list.h
@@ -214,7 +214,7 @@ void tag_list::init(std::initializer_list<Arg> init)
     el_type_ = T::type;
     tags.reserve(init.size());
     for(const Arg& arg: init)
-        tags.emplace_back(make_unique<T>(arg));
+        tags.emplace_back(nbt::make_unique<T>(arg));
 }
 
 }

--- a/src/text/json_formatter.cpp
+++ b/src/text/json_formatter.cpp
@@ -35,7 +35,7 @@ namespace //anonymous
     class json_fmt_visitor : public const_nbt_visitor
     {
     public:
-        json_fmt_visitor(std::ostream& os, const json_formatter& fmt):
+        json_fmt_visitor(std::ostream& os, const json_formatter&):
             os(os)
         {}
 


### PR DESCRIPTION
Fixed an ambiguous call to `nbt::make_unique` in `nbt::tag_list::init`.  This call was ambiguous due to [ADL](http://en.cppreference.com/w/cpp/language/adl) (`std::string` argument) and the existence of `std::make_unique` when building with a C++14-conforming library.

Removed the name from the second parameter to the constructor of `nbt::text::json_fmt_visitor` in `src/text/json_formatter.cpp` to eliminate a GCC warning about an unused parameter (`-Wunused-parameter` which comes as part of `-Wextra`).